### PR TITLE
Add Mongo Config Options

### DIFF
--- a/config_template.js
+++ b/config_template.js
@@ -11,13 +11,13 @@ module.exports = {
             // Update url with actual mongo connection string. 
             url: "mongodb://localhost:27017/des",
             // all options are optional
-            options: { 
+            /*options: { 
                 uri_decode_auth: ""
                 db: "",
                 server: "",
                 replSet: "",
                 promiseLibrary: ""
-            }
+            }*/
         },
         destiny: {
             apikey: "BUNGIE_TOKEN",

--- a/config_template.js
+++ b/config_template.js
@@ -8,7 +8,16 @@ module.exports = {
     },
     modules: {
         db : {
-            url: "mongodb://localhost:27017/des"
+            // Update url with actual mongo connection string. 
+            url: "mongodb://localhost:27017/des",
+            // all options are optional
+            options: { 
+                uri_decode_auth: ""
+                db: "",
+                server: "",
+                replSet: "",
+                promiseLibrary: ""
+            }
         },
         destiny: {
             apikey: "BUNGIE_TOKEN",


### PR DESCRIPTION
You have already implemented pretty much what I had suggested, so... I just added the config options to the config_template, making sure to comment them out. If not, they try to use all of them. The user should uncomment the options they need.
